### PR TITLE
feat: improve pagination in resolvers by introducing a many result type

### DIFF
--- a/packages/core/src/entities/Document.ts
+++ b/packages/core/src/entities/Document.ts
@@ -23,27 +23,27 @@ import { User } from './User';
 @ObjectType()
 export class Document implements BaseDocument {
   @PrimaryGeneratedColumn('uuid')
-  @GraphQLField()
+  @GraphQLField(_type => String)
   public id!: string;
 
   @Column()
-  @GraphQLField()
+  @GraphQLField(_type => String)
   public locale!: string;
 
   @Column({ type: 'jsonb' })
   @GraphQLField(_type => GraphQLJSON)
-  public data!: any; // eslint-disable-line
+  public data!: Record<string, any>; // eslint-disable-line
 
   @Column({ type: 'timestamp', nullable: true, default: null })
   @GraphQLField(_type => Date, { nullable: true })
   public publishedAt?: Date | null;
 
   @CreateDateColumn()
-  @GraphQLField()
+  @GraphQLField(_type => Date)
   public createdAt!: Date;
 
   @UpdateDateColumn()
-  @GraphQLField()
+  @GraphQLField(_type => Date)
   public updatedAt!: Date;
 
   @Column({ type: 'timestamp', nullable: true, default: null })
@@ -51,7 +51,7 @@ export class Document implements BaseDocument {
   public deletedAt?: Date | null;
 
   @Column()
-  @GraphQLField()
+  @GraphQLField(_type => String)
   public schemaId!: string;
 
   @ManyToOne(

--- a/packages/core/src/entities/Schema.ts
+++ b/packages/core/src/entities/Schema.ts
@@ -19,6 +19,7 @@ import { fireWebhooks } from '../utils/fire-webhooks';
 
 import { Field } from './Field';
 import { User } from './User';
+import { Document } from './Document';
 
 // Register the enum for type-graphql
 registerEnumType(SchemaType, { name: 'SchemaType' });

--- a/packages/field-reference-of/src/ui/Settings.vue
+++ b/packages/field-reference-of/src/ui/Settings.vue
@@ -7,7 +7,7 @@
         placeholder="Select the Schema to get all references from "
       >
         <a-select-option
-          v-for="schema in allSchemas"
+          v-for="schema in allSchemas.results"
           :key="schema.id"
         >
           {{ schema.name }}
@@ -44,12 +44,14 @@ export default {
       query: gql`
         query {
           allSchemas {
-            id
-            name
-            fields {
+            results {
               id
               name
-              type
+              fields {
+                id
+                name
+                type
+              }
             }
           }
         }
@@ -80,7 +82,7 @@ export default {
 
   data() {
     return {
-      allSchemas: [],
+      allSchemas: { results: [] },
     };
   },
 
@@ -121,7 +123,7 @@ export default {
     },
 
     referenceFields() {
-      const schema = find(this.allSchemas, (s) => s.id === this.schemaId);
+      const schema = find(this.allSchemas.results, (s) => s.id === this.schemaId);
 
       if (!schema) return [];
 

--- a/packages/field-reference/src/ui/Input.vue
+++ b/packages/field-reference/src/ui/Input.vue
@@ -81,8 +81,10 @@ export default {
       query: gql`
         query {
           allSchemas {
-            id
-            name
+            results {
+              id
+              name
+            }
           }
         }
       `,
@@ -113,7 +115,7 @@ export default {
 
   data() {
     return {
-      allSchemas: [],
+      allSchemas: { results: [] },
       documents: [],
       document: null,
       modalVisible: false,
@@ -137,8 +139,8 @@ export default {
     },
 
     schemaName() {
-      if (this.fieldData && this.allSchemas.length > 0) {
-        return find(this.allSchemas, (s) => s.id === this.fieldData.schemaId).name;
+      if (this.fieldData && this.allSchemas.results.length > 0) {
+        return find(this.allSchemas.results, (s) => s.id === this.fieldData.schemaId).name;
       }
 
       return null;

--- a/packages/field-reference/src/ui/Settings.vue
+++ b/packages/field-reference/src/ui/Settings.vue
@@ -11,7 +11,7 @@
         placeholder="Select the Schema's that documents can be reference"
       >
         <a-select-option
-          v-for="schema in allSchemas"
+          v-for="schema in allSchemas.results"
           :key="schema.name"
         >
           {{ schema.name }}
@@ -32,8 +32,10 @@ export default {
       query: gql`
         query {
           allSchemas {
-            id
-            name
+            results {
+              id
+              name
+            }
           }
         }
       `,
@@ -63,7 +65,7 @@ export default {
 
   data() {
     return {
-      allSchemas: [],
+      allSchemas: { results: [] },
     };
   },
 
@@ -84,12 +86,12 @@ export default {
         }
 
         return this.settings.schemaIds.map(
-          (x) => find(this.allSchemas, (s) => s.id === x).name,
+          (x) => find(this.allSchemas.results, (s) => s.id === x).name,
         );
       },
       set(value) {
         this.settings.schemaIds = value.map(
-          (x) => find(this.allSchemas, (s) => s.name === x).id,
+          (x) => find(this.allSchemas.results, (s) => s.name === x).id,
         );
       },
     },

--- a/packages/types/src/common/context/index.ts
+++ b/packages/types/src/common/context/index.ts
@@ -1,8 +1,8 @@
 import { User } from '../../entities';
 
 export interface SessionContext {
-  req: Request;
-  res: Response;
+  req: Express.Request;
+  res: Express.Response;
 }
 
 export interface GlobalContext extends SessionContext {

--- a/packages/types/src/common/graphql.ts
+++ b/packages/types/src/common/graphql.ts
@@ -1,0 +1,7 @@
+export interface FindManyResult<T> {
+  results: T[];
+  totalItems: number;
+  currentPage: number;
+  totalPages: number;
+  hasNextPage: boolean;
+}

--- a/packages/types/src/common/index.ts
+++ b/packages/types/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './context';
 export * from './field';
+export * from './graphql';

--- a/packages/ui/src/common/base-find-many-result.ts
+++ b/packages/ui/src/common/base-find-many-result.ts
@@ -1,0 +1,10 @@
+import { FindManyResult } from '@dockite/types';
+
+// eslint-disable-next-line
+export const baseFindManyResult: FindManyResult<any> = {
+  results: [],
+  currentPage: 1,
+  hasNextPage: false,
+  totalItems: 0,
+  totalPages: 1,
+};

--- a/packages/ui/src/components/base/SideMenu.vue
+++ b/packages/ui/src/components/base/SideMenu.vue
@@ -23,7 +23,7 @@
             Schemas
           </span>
         </router-link>
-        <a-menu-item v-for="schema in allSchemas" :key="`schema/${schema.name}`">
+        <a-menu-item v-for="schema in allSchemas.results" :key="`schema/${schema.name}`">
           <router-link :to="`/schema/${schema.name}`">
             {{ schema.name }}
           </router-link>
@@ -54,9 +54,11 @@
 </template>
 
 <script lang="ts">
-import { Schema } from '@dockite/types';
+import { Schema, FindManyResult } from '@dockite/types';
 import { gql } from 'apollo-boost';
 import { Component, Vue, Watch } from 'vue-property-decorator';
+
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -64,16 +66,18 @@ import { Component, Vue, Watch } from 'vue-property-decorator';
       query: gql`
         {
           allSchemas {
-            name
+            results {
+              id
+              name
+            }
           }
         }
       `,
-      // pollInterval: 30000,
     },
   },
 })
 export class BaseSideMenu extends Vue {
-  readonly allSchemas: Pick<Schema, 'name'>[] = [];
+  readonly allSchemas: FindManyResult<Pick<Schema, 'id' | 'name'>> = { ...baseFindManyResult };
 
   public collapsed = false;
 

--- a/packages/ui/src/queries/AllDocuments.gql
+++ b/packages/ui/src/queries/AllDocuments.gql
@@ -1,12 +1,14 @@
 query FetchAllDocuments {
   allDocuments {
-    id
-    data
-    updatedAt
-    createdAt
-    schema {
+    results {
       id
-      name
+      data
+      updatedAt
+      createdAt
+      schema {
+        id
+        name
+      }
     }
   }
 }

--- a/packages/ui/src/views/document/All.vue
+++ b/packages/ui/src/views/document/All.vue
@@ -57,9 +57,11 @@
 
 <script lang="ts">
 import FetchAllDocuments from '@/queries/AllDocuments.gql';
-import { Schema, Document } from '@dockite/types';
+import { Schema, Document, FindManyResult } from '@dockite/types';
 import moment from 'moment';
 import { Component, Vue } from 'vue-property-decorator';
+
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -71,7 +73,7 @@ import { Component, Vue } from 'vue-property-decorator';
 export class AllDocumentPage extends Vue {
   public moment = moment;
 
-  public allDocuments: Partial<Document>[] = [];
+  public allDocuments: FindManyResult<Partial<Document>> = { ...baseFindManyResult };
 
   get columns(): object[] {
     return [
@@ -109,8 +111,8 @@ export class AllDocumentPage extends Vue {
   }
 
   get source() {
-    if (this.allDocuments && this.allDocuments.length > 0) {
-      return this.allDocuments;
+    if (this.allDocuments.results && this.allDocuments.results.length > 0) {
+      return this.allDocuments.results;
     }
 
     return [];

--- a/packages/ui/src/views/schema/All.vue
+++ b/packages/ui/src/views/schema/All.vue
@@ -49,10 +49,12 @@
 </template>
 
 <script lang="ts">
-import { Schema } from '@dockite/types';
+import { Schema, FindManyResult } from '@dockite/types';
 import { gql } from 'apollo-boost';
 import moment from 'moment';
 import { Component, Vue } from 'vue-property-decorator';
+
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -60,12 +62,14 @@ import { Component, Vue } from 'vue-property-decorator';
       query: gql`
         query {
           schemas: allSchemas {
-            id
-            name
-            groups
-            settings
-            updatedAt
-            createdAt
+            results {
+              id
+              name
+              groups
+              settings
+              updatedAt
+              createdAt
+            }
           }
         }
       `,
@@ -75,7 +79,7 @@ import { Component, Vue } from 'vue-property-decorator';
 export class SchemaTableView extends Vue {
   public moment = moment;
 
-  public schemas!: Partial<Schema>[];
+  public schemas: FindManyResult<Partial<Schema>> = { ...baseFindManyResult };
 
   get columns(): object[] {
     return [
@@ -107,9 +111,9 @@ export class SchemaTableView extends Vue {
     ];
   }
 
-  get source() {
-    if (this.schemas && this.schemas.length > 0) {
-      return this.schemas;
+  get source(): Partial<Schema>[] {
+    if (this.schemas.results && this.schemas.results.length > 0) {
+      return this.schemas.results;
     }
 
     return [];

--- a/packages/ui/src/views/schema/View.vue
+++ b/packages/ui/src/views/schema/View.vue
@@ -36,11 +36,13 @@
 </template>
 
 <script lang="ts">
-import { Schema, Document } from '@dockite/types';
+import { Schema, Document, FindManyResult } from '@dockite/types';
 import { gql } from 'apollo-boost';
 import { startCase } from 'lodash';
 import moment from 'moment';
 import { Component, Vue } from 'vue-property-decorator';
+
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -71,10 +73,12 @@ import { Component, Vue } from 'vue-property-decorator';
       query: gql`
         query FindDocumentsForSchema($schemaId: String) {
           documents: findDocuments(schemaId: $schemaId) {
-            id
-            createdAt
-            updatedAt
-            data
+            results {
+              id
+              createdAt
+              updatedAt
+              data
+            }
           }
         }
       `,
@@ -94,7 +98,7 @@ export class SchemaTableView extends Vue {
 
   public moment = moment;
 
-  public documents!: Partial<Document>[];
+  public documents: FindManyResult<Document> = { ...baseFindManyResult };
 
   get columns(): object[] {
     if (this.schema && this.schema.fields) {
@@ -136,8 +140,8 @@ export class SchemaTableView extends Vue {
   }
 
   get source() {
-    if (this.documents && this.documents.length > 0) {
-      return this.documents.map(doc => {
+    if (this.documents.results && this.documents.results.length > 0) {
+      return this.documents.results.map(doc => {
         const data = doc.data ?? {};
 
         return { ...doc, ...data };

--- a/packages/ui/src/views/settings/Webhooks.vue
+++ b/packages/ui/src/views/settings/Webhooks.vue
@@ -23,7 +23,7 @@
     <a-table
       class="webhook-table"
       :columns="columns"
-      :data-source="allWebhooks"
+      :data-source="allWebhooks.results"
       :row-key="getRowKey"
     >
       <router-link slot="id" slot-scope="id" :to="`/settings/webhooks/history/${id}`">
@@ -122,7 +122,7 @@
 </template>
 
 <script lang="ts">
-import { WebhookAction } from '@dockite/types';
+import { WebhookAction, FindManyResult } from '@dockite/types';
 import {
   getIntrospectionQuery,
   buildClientSchema,
@@ -141,6 +141,7 @@ import 'codemirror/addon/lint/lint';
 import 'codemirror-graphql/hint';
 import 'codemirror-graphql/lint';
 import 'codemirror-graphql/mode';
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -148,11 +149,13 @@ import 'codemirror-graphql/mode';
       query: gql`
         query {
           allWebhooks {
-            id
-            name
-            method
-            url
-            updatedAt
+            results {
+              id
+              name
+              method
+              url
+              updatedAt
+            }
           }
         }
       `,
@@ -164,7 +167,7 @@ import 'codemirror-graphql/mode';
   },
 })
 export class WebhooksPage extends Vue {
-  public allWebhooks: object[] = [];
+  public allWebhooks: FindManyResult<object> = { ...baseFindManyResult };
 
   public introspectionQuery = getIntrospectionQuery();
 

--- a/packages/ui/src/views/settings/WebhooksHistory.vue
+++ b/packages/ui/src/views/settings/WebhooksHistory.vue
@@ -9,7 +9,7 @@
     <a-table
       class="webhook-table"
       :columns="columns"
-      :data-source="allWebhookCalls"
+      :data-source="allWebhookCalls.results"
       :row-key="getRowKey"
     >
       <router-link slot="id" slot-scope="id" :to="`/settings/webhooks/history/${id}`">
@@ -39,8 +39,11 @@
 </template>
 
 <script lang="ts">
+import { FindManyResult } from '@dockite/types';
 import gql from 'graphql-tag';
 import { Vue, Component, Watch } from 'vue-property-decorator';
+
+import { baseFindManyResult } from '../../common/base-find-many-result';
 
 @Component({
   apollo: {
@@ -48,10 +51,12 @@ import { Vue, Component, Watch } from 'vue-property-decorator';
       query: gql`
         query {
           allWebhookCalls {
-            id
-            success
-            status
-            executedAt
+            results {
+              id
+              success
+              status
+              executedAt
+            }
           }
         }
       `,
@@ -59,7 +64,7 @@ import { Vue, Component, Watch } from 'vue-property-decorator';
   },
 })
 export class WebhooksHistoryPage extends Vue {
-  public allWebhookCalls: object[] = [];
+  public allWebhookCalls: FindManyResult<object> = { ...baseFindManyResult };
 
   get columns() {
     return [


### PR DESCRIPTION
**Describe the issue that this pull request solves**

Currently when retrieving multiple items it's hard to paginate data due to no information being provided for the current result set.

**Describe the implmentation in simple terms**

The implementation adds a new GraphQL type for resolvers **(Many<EntitityName>** which resolvers that return many items now resolve to. This new type addresses the basics for pagination by including properties such as **currentPage**, **totalItems**, **totalPages**, etc.

**Link any associated issues**
#9  