### PR TITLE
fix(colorpicker): resolver always returns null

### DIFF
--- a/packages/field-colorpicker/src/.eslintrc
+++ b/packages/field-colorpicker/src/.eslintrc
@@ -39,7 +39,8 @@
         "ts": "never",
         "tsx": "never",
         "js": "never",
-        "jsx": "never"
+        "jsx": "never",
+        "mjs": "never"
       }
     ],
     "import/no-cycle": "off",

--- a/packages/field-colorpicker/src/index.ts
+++ b/packages/field-colorpicker/src/index.ts
@@ -35,8 +35,4 @@ export class DockiteFieldColorPicker extends DockiteField {
   ): Promise<GraphQLOutputType> {
     return DockiteFieldColorType;
   }
-
-  public async processOutput<T>(data: any): Promise<T> {
-    return data[this.schemaField.name] as T;
-  }
 }


### PR DESCRIPTION
During usage the graphql responses for the colorpicker field would always return null despite a value existing in the database. 

This was due to the processOutput hook using the old format from before an API change, this pull request resolves the issue and colorpicker fields now resolve correctly.