### PR TITLE
feat(core,admin): add document full text search

### DIFF
--- a/packages/admin/common/types/graphql/index.ts
+++ b/packages/admin/common/types/graphql/index.ts
@@ -47,6 +47,12 @@ export interface AllDocumentsWithSchemaQueryResponse {
   allDocuments: ManyResultsResponse<AllDocumentsWithSchemaResultItem>;
 }
 
+export type SearchDocumentsWithSchemaResultItem = Omit<Document, 'user' | 'userId' | 'schemaId'>;
+
+export interface SearchDocumentsWithSchemaQueryResponse {
+  searchDocuments: ManyResultsResponse<SearchDocumentsWithSchemaResultItem>;
+}
+
 export interface GetDocumentQueryResponse {
   getDocument: Document;
 }

--- a/packages/admin/graphql/queries/search-documents-with-schema.gql
+++ b/packages/admin/graphql/queries/search-documents-with-schema.gql
@@ -1,0 +1,27 @@
+query searchDocumentsWithSchema($term: String!, $schemaId: String) {
+  searchDocuments(term: $term, schemaId: $schemaId) {
+    results {
+      id
+      locale
+      data
+      publishedAt
+      createdAt
+      updatedAt
+      deletedAt
+      schemaId
+      schema {
+        id
+        name
+        type
+        groups
+        settings
+        createdAt
+        updatedAt
+      }
+    }
+    totalItems
+    currentPage
+    totalPages
+    hasNextPage
+  }
+}

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@nuxt/typescript-build": "^0.6.0",
-    "@nuxtjs/eslint-config-typescript": "^1.0.0",
+    "@nuxtjs/eslint-config-typescript": "1.0.1",
     "@nuxtjs/eslint-module": "^1.0.0",
     "@nuxtjs/stylelint-module": "^3.1.0",
     "@vue/test-utils": "^1.0.0-beta.27",

--- a/packages/admin/pages/documents/index.vue
+++ b/packages/admin/pages/documents/index.vue
@@ -1,7 +1,17 @@
 <template>
   <fragment>
     <portal to="header">
-      <h2>All Documents</h2>
+      <el-row type="flex" align="middle" justify="space-between">
+        <h2>All Documents</h2>
+
+        <el-input
+          v-model="term"
+          size="medium"
+          style="max-width: 250px"
+          placeholder="Search"
+          suffix-icon="el-icon-search"
+        />
+      </el-row>
     </portal>
 
     <div class="all-documents-page">
@@ -52,6 +62,7 @@
       <el-row type="flex" justify="space-between">
         <span />
         <el-pagination
+          v-show="term === ''"
           :current-page="currentPage"
           class="dockite-element--pagination"
           :page-count="totalPages"
@@ -69,7 +80,7 @@
 
 <script lang="ts">
 import { formatDistanceToNow } from 'date-fns';
-import { Component, Vue } from 'nuxt-property-decorator';
+import { Component, Vue, Watch } from 'nuxt-property-decorator';
 import { Fragment } from 'vue-fragment';
 
 import { ManyResultSet, AllDocumentsWithSchemaResultItem } from '../../common/types';
@@ -82,10 +93,12 @@ import * as data from '~/store/data';
   },
 })
 export default class AllDocumentsPage extends Vue {
+  public term = '';
+
   get allDocumentsWithSchema(): ManyResultSet<AllDocumentsWithSchemaResultItem> {
     const state: data.DataState = this.$store.state[data.namespace];
 
-    return state.allDocumentsWithSchema;
+    return this.term === '' ? state.allDocumentsWithSchema : state.searchDocumentsWithSchema;
   }
 
   get currentPage(): number {
@@ -122,6 +135,13 @@ export default class AllDocumentsPage extends Vue {
 
   public handlePageChange(newPage: number): void {
     this.fetchAllDocumentsWithSchema(newPage);
+  }
+
+  @Watch('term')
+  public handleTermChange(newTerm: string): void {
+    if (newTerm !== '') {
+      this.$store.dispatch(`${data.namespace}/fetchSearchDocumentsWithSchema`, { term: newTerm });
+    }
   }
 
   mounted(): void {

--- a/packages/admin/pages/schemas/_id/index.vue
+++ b/packages/admin/pages/schemas/_id/index.vue
@@ -6,32 +6,41 @@
           Schema - <strong>{{ schemaName }}</strong>
         </h2>
 
-        <el-dropdown>
-          <el-button size="medium">
-            Actions
-            <i class="el-icon-arrow-down el-icon--right" />
-          </el-button>
-          <el-dropdown-menu slot="dropdown">
-            <el-dropdown-item>
-              <router-link :to="`/schemas/${schemaId}/create`">
-                <i class="el-icon-document-add" />
-                Create
-              </router-link>
-            </el-dropdown-item>
-            <el-dropdown-item>
-              <router-link :to="`/schemas/${schemaId}/edit`">
-                <i class="el-icon-edit" />
-                Edit
-              </router-link>
-            </el-dropdown-item>
-            <el-dropdown-item>
-              <router-link :to="`/schemas/${schemaId}/delete`" style="color: rgb(245, 108, 108)">
-                <i class="el-icon-delete" />
-                Delete
-              </router-link>
-            </el-dropdown-item>
-          </el-dropdown-menu>
-        </el-dropdown>
+        <el-row type="flex" align="middle">
+          <el-input
+            v-model="term"
+            size="medium"
+            style="max-width: 250px; margin-right: 1rem;"
+            placeholder="Search"
+            suffix-icon="el-icon-search"
+          />
+          <el-dropdown>
+            <el-button size="medium">
+              Actions
+              <i class="el-icon-arrow-down el-icon--right" />
+            </el-button>
+            <el-dropdown-menu slot="dropdown">
+              <el-dropdown-item>
+                <router-link :to="`/schemas/${schemaId}/create`">
+                  <i class="el-icon-document-add" />
+                  Create
+                </router-link>
+              </el-dropdown-item>
+              <el-dropdown-item>
+                <router-link :to="`/schemas/${schemaId}/edit`">
+                  <i class="el-icon-edit" />
+                  Edit
+                </router-link>
+              </el-dropdown-item>
+              <el-dropdown-item>
+                <router-link :to="`/schemas/${schemaId}/delete`" style="color: rgb(245, 108, 108)">
+                  <i class="el-icon-delete" />
+                  Delete
+                </router-link>
+              </el-dropdown-item>
+            </el-dropdown-menu>
+          </el-dropdown>
+        </el-row>
       </el-row>
     </portal>
 
@@ -77,6 +86,7 @@
       <el-row type="flex" justify="space-between">
         <span />
         <el-pagination
+          v-show="term === ''"
           :current-page="currentPage"
           class="dockite-element--pagination"
           :page-count="totalPages"
@@ -97,7 +107,11 @@ import { formatDistanceToNow } from 'date-fns';
 import { Component, Vue, Watch } from 'nuxt-property-decorator';
 import { Fragment } from 'vue-fragment';
 
-import { ManyResultSet, FindDocumentResultItem } from '../../../common/types';
+import {
+  ManyResultSet,
+  FindDocumentResultItem,
+  SearchDocumentsWithSchemaResultItem,
+} from '../../../common/types';
 
 import * as data from '~/store/data';
 
@@ -107,10 +121,14 @@ import * as data from '~/store/data';
   },
 })
 export default class SchemaDocumentsPage extends Vue {
-  get findDocumentsBySchemaId(): ManyResultSet<FindDocumentResultItem> {
+  public term = '';
+
+  get findDocumentsBySchemaId(): ManyResultSet<
+    FindDocumentResultItem | SearchDocumentsWithSchemaResultItem
+  > {
     const state: data.DataState = this.$store.state[data.namespace];
 
-    return state.findDocumentsBySchemaId;
+    return this.term === '' ? state.findDocumentsBySchemaId : state.searchDocumentsWithSchema;
   }
 
   get schemaId(): string {
@@ -163,6 +181,16 @@ export default class SchemaDocumentsPage extends Vue {
   @Watch('schemaId', { immediate: true })
   handleSchemaIdChange(): void {
     this.fetchFindDocumentsBySchemaId();
+  }
+
+  @Watch('term')
+  public handleTermChange(newTerm: string): void {
+    if (newTerm !== '') {
+      this.$store.dispatch(`${data.namespace}/fetchSearchDocumentsWithSchema`, {
+        term: newTerm,
+        schemaId: this.schemaId,
+      });
+    }
   }
 }
 </script>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "apollo-server-express": "^2.10.1",
     "axios": "^0.19.2",
     "bcrypt": "^4.0.0",
+    "class-validator": "^0.12.2",
     "cosmiconfig": "^6.0.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -18,7 +18,9 @@ export const connect = async (): Promise<Connection> => {
 
   log('collecting registered entities');
   if (config.entities && config.entities.length > 0) {
-    externalEntities = await Promise.all(config.entities.map(x => import(x)));
+    externalEntities = await Promise.all(
+      config.entities.map(x => import(x).then(i => Promise.resolve(i))),
+    );
   }
 
   log('creating database connection');
@@ -34,6 +36,8 @@ export const connect = async (): Promise<Connection> => {
     logging: ['query', 'error'],
     logger: 'debug',
   });
+
+  await connection.synchronize();
 
   return connection;
 };

--- a/packages/core/src/entities/SearchEngine.ts
+++ b/packages/core/src/entities/SearchEngine.ts
@@ -1,0 +1,70 @@
+import { ViewColumn, ViewEntity, Index, ManyToOne, PrimaryColumn } from 'typeorm';
+
+import { Document } from './Document';
+import { Schema } from './Schema';
+import { Release } from './Release';
+
+@ViewEntity({
+  expression: conn =>
+    conn
+      .createQueryBuilder()
+      .select('document.*')
+      .addSelect(`to_tsvector('pg_catalog.simple', document.data)`, 'fts')
+      .from(Document, 'document'),
+})
+export class SearchEngine {
+  @ViewColumn()
+  @PrimaryColumn()
+  public id!: string;
+
+  @ViewColumn()
+  public locale!: string;
+
+  @ViewColumn()
+  public data!: Record<string, any>; // eslint-disable-line
+
+  @ViewColumn()
+  public publishedAt?: Date | null;
+
+  @ViewColumn()
+  public createdAt!: Date;
+
+  @ViewColumn()
+  public updatedAt!: Date;
+
+  @ViewColumn()
+  public deletedAt?: Date | null;
+
+  @ViewColumn()
+  public schemaId!: string;
+
+  @ManyToOne(
+    _type => Schema,
+    schema => schema.documents,
+    {
+      onDelete: 'SET NULL',
+      nullable: true,
+    },
+  )
+  public schema!: Schema;
+
+  @ViewColumn()
+  public releaseId?: string | null;
+
+  @ManyToOne(
+    _type => Release,
+    release => release.documents,
+    {
+      onDelete: 'SET NULL',
+      nullable: true,
+    },
+  )
+  public release!: Release;
+
+  @ViewColumn()
+  public userId?: string | null;
+
+  @ViewColumn()
+  @Index()
+  public fts!: any;
+}

--- a/packages/core/src/entities/index.ts
+++ b/packages/core/src/entities/index.ts
@@ -2,6 +2,7 @@ export * from './Document';
 export * from './Field';
 export * from './Release';
 export * from './Schema';
+export * from './SearchEngine';
 export * from './User';
 export * from './Webhook';
 export * from './WebhookCall';

--- a/packages/core/src/modules/authentication/index.ts
+++ b/packages/core/src/modules/authentication/index.ts
@@ -10,6 +10,7 @@ import { GlobalContext } from '../../common/types';
 import * as resolvers from './resolvers';
 
 const log = debug('dockite:core:authentication');
+const tlog = debug('dockite:core:authentication:timer');
 
 const Module: GraphQLModule | null = null;
 
@@ -19,6 +20,7 @@ export const AuthenticationGraphQLModule = async (): Promise<GraphQLModule<
   GlobalContext,
   any
 >> => {
+  tlog('starting');
   if (Module) {
     return Module;
   }
@@ -26,8 +28,6 @@ export const AuthenticationGraphQLModule = async (): Promise<GraphQLModule<
   const resolverPromises = ((await Promise.all(
     Object.values(resolvers).map(r => Promise.resolve(r)),
   )) as any[]) as [Function, ...Function[]];
-
-  log({ resolverPromises });
 
   log('building type-definitions and resolvers');
   const typeDefsAndResolvers = await buildTypeDefsAndResolvers({
@@ -37,6 +37,7 @@ export const AuthenticationGraphQLModule = async (): Promise<GraphQLModule<
   });
 
   log('creating graphql module');
+  tlog('ending');
   return new GraphQLModule({
     typeDefs: typeDefsAndResolvers.typeDefs,
     resolvers: typeDefsAndResolvers.resolvers,

--- a/packages/core/src/modules/external/index.ts
+++ b/packages/core/src/modules/external/index.ts
@@ -9,6 +9,7 @@ import { createExtraGraphQLSchema } from './dockite';
 import * as resolvers from './resolvers';
 
 const log = debug('dockite:core:external');
+const tlog = debug('dockite:core:external:timer');
 
 // eslint-disable-next-line
 export const getRegisteredExternalModules = (): any[] => {
@@ -21,13 +22,12 @@ export const ExternalGraphQLModule = async (): Promise<GraphQLModule<
   GlobalContext,
   any
 >> => {
+  tlog('starting');
   log('building type-definitions and resolvers');
 
   const resolverPromises = ((await Promise.all(
     Object.values(resolvers).map(r => Promise.resolve(r)),
   )) as any[]) as [Function, ...Function[]];
-
-  log({ resolverPromises });
 
   const externalSchema = await buildTypeDefsAndResolvers({
     resolvers: resolverPromises,
@@ -35,17 +35,14 @@ export const ExternalGraphQLModule = async (): Promise<GraphQLModule<
     // emitSchemaFile: path.join(__dirname, './schema.gql'),
   });
 
-  log('external', externalSchema);
-
   log('collecting registered modules');
   const modules = await Promise.all(getRegisteredExternalModules());
-
-  log('modules', modules);
 
   log('creating graphql schemas for content types');
   const schema = await createExtraGraphQLSchema();
 
   log('creating graphql module');
+  tlog('ending');
   return new GraphQLModule({
     typeDefs: externalSchema.typeDefs,
     resolvers: externalSchema.resolvers,

--- a/packages/core/src/modules/internal/index.ts
+++ b/packages/core/src/modules/internal/index.ts
@@ -11,6 +11,7 @@ import { GlobalContext } from '../../common/types';
 import * as resolvers from './resolvers';
 
 const log = debug('dockite:core:internal');
+const tlog = debug('dockite:core:internal:timer');
 
 // eslint-disable-next-line
 export const getRegisteredInternalModules = (): any[] => {
@@ -23,13 +24,12 @@ export const InternalGraphQLModule = async (): Promise<GraphQLModule<
   GlobalContext,
   any
 >> => {
+  tlog('starting');
   log('building type-definitions and resolvers');
 
   const resolverPromises = ((await Promise.all(
     Object.values(resolvers).map(r => Promise.resolve(r)),
   )) as any[]) as [Function, ...Function[]];
-
-  log({ resolverPromises });
 
   const typeDefsAndResolvers = await buildTypeDefsAndResolvers({
     authChecker,
@@ -41,6 +41,7 @@ export const InternalGraphQLModule = async (): Promise<GraphQLModule<
   const modules = await Promise.all(getRegisteredInternalModules());
 
   log('creating graphql module');
+  tlog('ending');
   return new GraphQLModule({
     typeDefs: typeDefsAndResolvers.typeDefs,
     resolvers: typeDefsAndResolvers.resolvers,

--- a/packages/core/src/repositories/SearchEngine.ts
+++ b/packages/core/src/repositories/SearchEngine.ts
@@ -1,0 +1,12 @@
+import { Repository, getRepository, SelectQueryBuilder, EntityRepository } from 'typeorm';
+
+import { SearchEngine } from '../entities/SearchEngine';
+
+@EntityRepository(SearchEngine)
+export class SearchEngineRepository extends Repository<SearchEngine> {
+  public search(term: string): SelectQueryBuilder<SearchEngine> {
+    return getRepository(SearchEngine)
+      .createQueryBuilder('searchEngine')
+      .where(`fts @@ to_tsquery('pg_catalog.simple', :term)`, { term });
+  }
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -60,11 +60,13 @@ export const start = async (port = process.env.PORT || 3000): Promise<Server> =>
   // app.use('/admin', express.static(path.dirname(require.resolve('@dockite/ui'))));
   // app.all('/admin*', (_req, res) => res.sendFile(require.resolve('@dockite/ui')));
 
+  log('collecting modules');
   const [root, external] = await Promise.all([RootModule(), ExternalGraphQLModule()]);
 
   SchemaStore.internalSchema = root.schema;
   SchemaStore.externalSchema = external.schema;
 
+  log('creating servers');
   const internalServer = new ApolloServer({
     schema: root.schema,
     context: ({ req, res }: SessionContext): GlobalContext => {
@@ -91,6 +93,7 @@ export const start = async (port = process.env.PORT || 3000): Promise<Server> =>
     playground: true,
   });
 
+  log('attaching servers');
   internalServer.applyMiddleware({ app, path: `/${INTERNAL_GRAPHQL_PATH}` });
   externalServer.applyMiddleware({ app, path: `/${EXTERNAL_GRAPHQL_PATH}` });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,22 +2515,22 @@
     consola "^2.10.1"
     dotenv "^8.1.0"
 
-"@nuxtjs/eslint-config-typescript@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-1.0.2.tgz#036811eb636ffdc0ad0ac1f655a089d4e63e4fed"
-  integrity sha512-oexvSNcHQhgLZbJvAeL6e/6pOo9Fv8VQbByZfG/0+6zrRrb5zW8uuRk06PIGeiq45YOHjrJKJ0xg/f2JVYav/Q==
+"@nuxtjs/eslint-config-typescript@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-1.0.1.tgz#3f1dfd59af3f39c3fb96d6a91488b11710c8a9d2"
+  integrity sha512-9CafuGlIvWw5AQJwZQuzveq9MKsPinyMIwEp0/ogLHPdpygNzdA+Rx0GVtmla5vJpph9WAgpvmvhkN0mfL3PLg==
   dependencies:
-    "@nuxtjs/eslint-config" "2.0.2"
+    "@nuxtjs/eslint-config" "2.0.1"
     "@typescript-eslint/eslint-plugin" "^2.19.0"
     "@typescript-eslint/parser" "^2.19.0"
 
-"@nuxtjs/eslint-config@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config/-/eslint-config-2.0.2.tgz#ff521ee1c0b875ac340f17ed656db213b6af854e"
-  integrity sha512-Vbs8dk73nc7alUoBvYtn6mNcDaK5LgnKZFljFbsGv7zsWFdr9ciear37+y8HBjWafD900cG45D7ae/n4D0BrRQ==
+"@nuxtjs/eslint-config@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config/-/eslint-config-2.0.1.tgz#820980c2270d1a58c5bd6135c93eef709be90b37"
+  integrity sha512-j5MXq932isxl3VPhQFZc5lpBdRGg9KJwxrLu+/TVdHzHN9rM36D3y5tG3i2WybDeGSDvYPRWquvCl4+5p229sg==
   dependencies:
     eslint-config-standard "^14.1.0"
-    eslint-plugin-import "2.19.1"
+    eslint-plugin-import "^2.20.1"
     eslint-plugin-jest "^23.7.0"
     eslint-plugin-node "^11.0.0"
     eslint-plugin-promise "^4.2.1"
@@ -3422,6 +3422,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/validator@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.0.0.tgz#365f1bf936aeaddd0856fc41aa1d6f82d88ee5b3"
+  integrity sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw==
 
 "@types/vfile-message@*", "@types/vfile-message@^2.0.0":
   version "2.0.0"
@@ -5684,6 +5689,16 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+class-validator@^0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.12.2.tgz#2ceb72f88873e9c714cf5f9c278cbc71f6f6c8ef"
+  integrity sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==
+  dependencies:
+    "@types/validator" "13.0.0"
+    google-libphonenumber "^3.2.8"
+    tslib ">=1.9.0"
+    validator "13.0.0"
+
 classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
@@ -7526,24 +7541,6 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-import@2.19.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz#5654e10b7839d064dd0d46cd1b88ec2133a11448"
-  integrity sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==
-  dependencies:
-    array-includes "^3.0.3"
-    array.prototype.flat "^1.2.1"
-    contains-path "^0.1.0"
-    debug "^2.6.9"
-    doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.2"
-    eslint-module-utils "^2.4.1"
-    has "^1.0.3"
-    minimatch "^3.0.4"
-    object.values "^1.1.0"
-    read-pkg-up "^2.0.0"
-    resolve "^1.12.0"
-
 eslint-plugin-import@^2.20.1:
   version "2.20.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz#91fc3807ce08be4837141272c8b99073906e588d"
@@ -8761,6 +8758,11 @@ gonzales-pe@^4.2.3:
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
   dependencies:
     minimist "^1.2.5"
+
+google-libphonenumber@^3.2.8:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz#021a314652747d736a39e2e60dc670f0431425ad"
+  integrity sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==
 
 got@^6.7.1:
   version "6.7.1"
@@ -16397,6 +16399,11 @@ tslib@1.11.2, tslib@^1, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.2.tgz#9c79d83272c9a7aaf166f73915c9667ecdde3cc9"
   integrity sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==
 
+tslib@>=1.9.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tslib@^1.10.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -16926,7 +16933,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@^13.0.0:
+validator@13.0.0, validator@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
   integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==


### PR DESCRIPTION
Add a full text search on the document table to allow for simple yet powerful searching of documents.

This is achieved by creating a ViewEntity with the additional `fts` column, this may need to be revised into a trigger based strategy later on depending on scalability.

Additionally adds required UI components and log for utilising the full text search which is displayed on both documents and schema document listing pages.