### PR TITLE
fix(admin): manage apollo cache hits

### DIFF
--- a/packages/admin/graphql/mutations/create-document.gql
+++ b/packages/admin/graphql/mutations/create-document.gql
@@ -1,5 +1,13 @@
 mutation CreateDocumentMutation($schemaId: String!, $data: JSON!, $locale: String!) {
   createDocument(schemaId: $schemaId, data: $data, locale: $locale) {
     id
+    locale
+    data
+    publishedAt
+    createdAt
+    updatedAt
+    schemaId
+    releaseId
+    userId
   }
 }

--- a/packages/admin/graphql/mutations/create-field.gql
+++ b/packages/admin/graphql/mutations/create-field.gql
@@ -15,5 +15,11 @@ mutation CreateField(
     settings: $settings
   ) {
     id
+    name
+    title
+    description
+    type
+    settings
+    schemaId
   }
 }

--- a/packages/admin/graphql/mutations/create-schema.gql
+++ b/packages/admin/graphql/mutations/create-schema.gql
@@ -1,5 +1,12 @@
 mutation CreateSchema($name: String!, $type: SchemaType!, $groups: JSON!, $settings: JSON!) {
   createSchema(name: $name, type: $type, groups: $groups, settings: $settings) {
     id
+    name
+    type
+    groups
+    settings
+    userId
+    createdAt
+    updatedAt
   }
 }

--- a/packages/admin/graphql/mutations/update-document.gql
+++ b/packages/admin/graphql/mutations/update-document.gql
@@ -1,5 +1,13 @@
 mutation UpdateDocumentMutation($id: String!, $data: JSON!) {
   updateDocument(id: $id, data: $data) {
     id
+    locale
+    data
+    publishedAt
+    createdAt
+    updatedAt
+    schemaId
+    releaseId
+    userId
   }
 }

--- a/packages/admin/graphql/mutations/update-field.gql
+++ b/packages/admin/graphql/mutations/update-field.gql
@@ -15,5 +15,11 @@ mutation UpdateField(
     settings: $settings
   ) {
     id
+    name
+    title
+    description
+    type
+    settings
+    schemaId
   }
 }

--- a/packages/admin/graphql/mutations/update-schema.gql
+++ b/packages/admin/graphql/mutations/update-schema.gql
@@ -1,5 +1,12 @@
 mutation UpdateSchemaMutation($id: String!, $groups: JSON!, $settings: JSON!) {
   updateSchema(id: $id, groups: $groups, settings: $settings) {
     id
+    name
+    type
+    groups
+    settings
+    userId
+    createdAt
+    updatedAt
   }
 }

--- a/packages/admin/pages/documents/_id/index.vue
+++ b/packages/admin/pages/documents/_id/index.vue
@@ -326,6 +326,6 @@ export default class UpdateDocumentPage extends Vue {
 .dockite-document--actions-drawer-revisions {
   flex: 1;
   overflow-y: auto;
-  padding-bottom: 1rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/packages/admin/pages/schemas/_id/edit.vue
+++ b/packages/admin/pages/schemas/_id/edit.vue
@@ -26,9 +26,16 @@
                 <el-button type="text" size="mini" @click="fieldToBeEdited = data">
                   Edit
                 </el-button>
-                <el-button type="text" size="mini" @click="handleRemoveField(node, data)">
-                  Remove
-                </el-button>
+                <el-popconfirm
+                  title="Are you sure? All documents will lose any data stored for this field."
+                  confirm-button-text="Delete"
+                  cancel-button-text="Cancel"
+                  @onConfirm="handleRemoveField(node, data)"
+                >
+                  <el-button slot="reference" type="text" size="mini">
+                    Remove
+                  </el-button>
+                </el-popconfirm>
               </span>
             </span>
           </el-tree>

--- a/packages/admin/store/data.ts
+++ b/packages/admin/store/data.ts
@@ -167,6 +167,7 @@ export const actions: ActionTree<DataState, RootState> = {
   ): Promise<void> {
     const { data } = await this.$apolloClient.query<AllSchemaRevisionsQueryResponse>({
       query: AllSchemaRevisionsQuery,
+      fetchPolicy: 'no-cache',
       variables: {
         schemaId: payload.schemaId,
         perPage: payload.perPage ?? null,
@@ -185,6 +186,7 @@ export const actions: ActionTree<DataState, RootState> = {
   ): Promise<void> {
     const { data } = await this.$apolloClient.query<AllDocumentRevisionsQueryResponse>({
       query: AllDocumentRevisionsQuery,
+      fetchPolicy: 'no-cache',
       variables: {
         documentId: payload.documentId,
         perPage: payload.perPage ?? null,
@@ -301,6 +303,7 @@ export const actions: ActionTree<DataState, RootState> = {
     const { data } = await this.$apolloClient.query<FindWebhookCallsQueryResponse>({
       query: FindWebhookCallsByWebhookIdQuery,
       variables: { id: payload.webhookId, page: payload.page ?? 1 },
+      fetchPolicy: 'no-cache',
     });
 
     if (!data.findWebhookCalls) {

--- a/packages/admin/store/document.ts
+++ b/packages/admin/store/document.ts
@@ -10,8 +10,6 @@ import {
 import CreateDocumentMutation from '~/graphql/mutations/create-document.gql';
 import DeleteDocumentMutation from '~/graphql/mutations/delete-document.gql';
 import UpdateDocumentMutation from '~/graphql/mutations/update-document.gql';
-import AllDocumentsWithSchemaQuery from '~/graphql/queries/all-documents-with-schema.gql';
-import FindDocumentsBySchemaIdQuery from '~/graphql/queries/find-documents-by-schema-id.gql';
 import * as data from '~/store/data';
 
 export interface DocumentState {
@@ -48,10 +46,6 @@ export const actions: ActionTree<DocumentState, RootState> = {
         data: payload.data,
         locale: DEFAULT_LOCALE,
       },
-      refetchQueries: [
-        { query: AllDocumentsWithSchemaQuery },
-        { query: FindDocumentsBySchemaIdQuery, variables: { id: payload.schemaId } },
-      ],
     });
 
     if (!data?.createDocument) {
@@ -67,10 +61,6 @@ export const actions: ActionTree<DocumentState, RootState> = {
         data: payload.data,
         locale: DEFAULT_LOCALE,
       },
-      refetchQueries: [
-        { query: AllDocumentsWithSchemaQuery },
-        { query: FindDocumentsBySchemaIdQuery, variables: { id: payload.schemaId } },
-      ],
     });
 
     if (!documentData?.updateDocument) {
@@ -86,10 +76,10 @@ export const actions: ActionTree<DocumentState, RootState> = {
       variables: {
         id: payload.documentId,
       },
-      refetchQueries: [
-        { query: AllDocumentsWithSchemaQuery },
-        { query: FindDocumentsBySchemaIdQuery, variables: { id: payload.schemaId } },
-      ],
+      // TODO: Update to cache eviction with @apollo/client 3.0.0
+      update: () => {
+        this.$apolloClient.resetStore();
+      },
     });
 
     if (!data?.removeDocument) {

--- a/packages/admin/store/revision.ts
+++ b/packages/admin/store/revision.ts
@@ -8,6 +8,7 @@ import {
 } from '~/common/types';
 import RestoreDocumentRevisionMutation from '~/graphql/mutations/restore-document-revision.gql';
 import RestoreSchemaRevisionMutation from '~/graphql/mutations/restore-schema-revision.gql';
+import * as data from '~/store/data';
 
 export interface RevisionState {
   errors: string | string[] | null;
@@ -35,29 +36,43 @@ export const getters: GetterTree<RevisionState, RootState> = {};
 
 export const actions: ActionTree<RevisionState, RootState> = {
   async restoreDocumentRevision(_, payload: RestoreDocumentRevisionPayload): Promise<void> {
-    const { data } = await this.$apolloClient.mutate<RestoreDocumentRevisionMutationResponse>({
+    const { data: revisionData } = await this.$apolloClient.mutate<
+      RestoreDocumentRevisionMutationResponse
+    >({
       mutation: RestoreDocumentRevisionMutation,
       variables: {
         revisionId: payload.revisionId,
         documentId: payload.documentId,
       },
+      update: () => {
+        this.$apolloClient.resetStore();
+      },
     });
 
-    if (!data?.restoreDocumentRevision) {
+    this.commit(`${data.namespace}/removeDocument`, payload.documentId);
+
+    if (!revisionData?.restoreDocumentRevision) {
       throw new Error('Unable to restore document revision');
     }
   },
 
   async restoreSchemaRevision(_, payload: RestoreSchemaRevisionPayload): Promise<void> {
-    const { data } = await this.$apolloClient.mutate<RestoreSchemaRevisionMutationResponse>({
+    const { data: revisionData } = await this.$apolloClient.mutate<
+      RestoreSchemaRevisionMutationResponse
+    >({
       mutation: RestoreSchemaRevisionMutation,
       variables: {
         revisionId: payload.revisionId,
         schemaId: payload.schemaId,
       },
+      update: () => {
+        this.$apolloClient.resetStore();
+      },
     });
 
-    if (!data?.restoreSchemaRevision) {
+    this.commit(`${data.namespace}/removeSchemaWithFields`, payload.schemaId);
+
+    if (!revisionData?.restoreSchemaRevision) {
       throw new Error('Unable to restore schema revision');
     }
   },

--- a/packages/admin/store/webhook.ts
+++ b/packages/admin/store/webhook.ts
@@ -10,7 +10,6 @@ import {
 import CreateWebhookMutation from '~/graphql/mutations/create-webhook.gql';
 import DeleteWebhookMutation from '~/graphql/mutations/delete-document.gql';
 import UpdateWebhookMutation from '~/graphql/mutations/update-document.gql';
-import AllWebhooksQuery from '~/graphql/queries/all-webhooks.gql';
 
 export interface WebhookState {
   errors: null | string | string[];
@@ -49,7 +48,6 @@ export const actions: ActionTree<WebhookState, RootState> = {
         method: payload.method,
         options: payload.options,
       },
-      refetchQueries: [{ query: AllWebhooksQuery }],
     });
 
     if (!data?.createWebhook) {
@@ -67,7 +65,6 @@ export const actions: ActionTree<WebhookState, RootState> = {
         method: payload.method,
         options: payload.options,
       },
-      refetchQueries: [{ query: AllWebhooksQuery }],
     });
 
     if (!documentData?.updateWebhook) {
@@ -81,7 +78,9 @@ export const actions: ActionTree<WebhookState, RootState> = {
       variables: {
         documentId: payload.webhookId,
       },
-      refetchQueries: [{ query: AllWebhooksQuery }],
+      update: () => {
+        this.$apolloClient.resetStore();
+      },
     });
 
     if (!data?.removeWebhook) {


### PR DESCRIPTION
The apollo cache is proving to be a burden with a number of cache hits occurring during updates or deletions requiring a full page reload to evict them. 

To manage this an update has been applied to improve the following of best practices for the apollo cache in addition to calling `resetStore` during any destructive activities until we can use `evict` with `@apollo/client:3.0.0`.