### PR TITLE
feat(core,admin): add schema imports

### DIFF
--- a/packages/admin/common/types/graphql/index.ts
+++ b/packages/admin/common/types/graphql/index.ts
@@ -95,15 +95,15 @@ export interface AvailableFieldsQueryResponse {
 }
 
 export interface CreateSchemaMutationResponse {
-  createSchema: {
-    id: string;
-  };
+  createSchema: Schema;
 }
 
 export interface UpdateSchemaMutationResponse {
-  updateSchema: {
-    id: string;
-  };
+  updateSchema: Schema;
+}
+
+export interface ImportSchemaMutationResponse {
+  importSchema: Schema;
 }
 
 export interface DeleteSchemaMutationResponse {

--- a/packages/admin/components/schemas/import-editor.vue
+++ b/packages/admin/components/schemas/import-editor.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="dockite-import--editor">
+    <textarea ref="codemirrorTextarea"></textarea>
+  </div>
+</template>
+
+<script lang="ts">
+import CodeMirror from 'codemirror';
+import jsonlint from 'jsonlint-mod';
+import { Component, Prop, Vue, Watch, Ref } from 'nuxt-property-decorator';
+
+import 'codemirror/theme/nord.css';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/addon/lint/lint';
+import 'codemirror/addon/lint/lint.css';
+import 'codemirror/addon/lint/json-lint';
+
+@Component
+export default class ImportEditorComponent extends Vue {
+  @Prop()
+  readonly value!: string;
+
+  @Ref()
+  readonly codemirrorTextarea!: HTMLTextAreaElement;
+
+  public editor!: CodeMirror.EditorFromTextArea;
+
+  public loadScript(location: string): Promise<void> {
+    return new Promise(resolve => {
+      const script = window.document.createElement('script');
+      script.src = location;
+      script.onload = () => resolve();
+      window.document.body.appendChild(script);
+    });
+  }
+
+  mounted(): void {
+    if (!this.editor) {
+      (window as any).jsonlint = jsonlint;
+
+      this.editor = CodeMirror.fromTextArea(this.codemirrorTextarea, {
+        value: this.value,
+        mode: 'application/json',
+        gutters: ['CodeMirror-lint-markers'],
+        lineNumbers: true,
+        lineWrapping: true,
+        lint: true,
+        tabSize: 2,
+        theme: 'nord',
+      });
+
+      this.editor.setSize('100%', '100%');
+
+      this.editor.on('blur', cm => {
+        this.$emit('input', cm.getValue());
+      });
+    }
+  }
+
+  destroyed(): void {
+    delete (window as any).jsonlint;
+  }
+
+  @Watch('value')
+  handleValueChange(value: string): void {
+    this.editor.setValue(value);
+  }
+}
+</script>
+
+<style lang="scss">
+.dockite-import--editor {
+  .CodeMirror {
+    box-sizing: border-box;
+    line-height: normal;
+    padding: 0.5rem 0;
+    margin-bottom: 0.25rem;
+  }
+}
+</style>

--- a/packages/admin/graphql/mutations/import-schema.gql
+++ b/packages/admin/graphql/mutations/import-schema.gql
@@ -1,0 +1,13 @@
+mutation ImportSchema($schemaId: String, $payload: JSON!) {
+  importSchema(schemaId: $schemaId, payload: $payload) {
+    id
+    title
+    name
+    type
+    groups
+    settings
+    userId
+    createdAt
+    updatedAt
+  }
+}

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -40,6 +40,7 @@
     "element-ui": "^2.4.11",
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",
+    "jsonlint-mod": "^1.7.5",
     "lodash": "^4.17.15",
     "normalize.css": "^8.0.1",
     "nuxt": "^2.0.0",

--- a/packages/admin/pages/schemas/_id/import.vue
+++ b/packages/admin/pages/schemas/_id/import.vue
@@ -1,0 +1,103 @@
+<template>
+  <fragment>
+    <portal to="header">
+      <h2>Import Schema</h2>
+    </portal>
+
+    <div class="import-schema-page">
+      <import-editor v-model="payload" style="height: 60vh;" />
+      <div style="padding-top: 1rem;" />
+      <el-row type="flex" justify="space-between" align="middle">
+        <el-button type="text" @click="$router.go(-1)">Cancel</el-button>
+        <el-button type="primary" @click.prevent="handleImportSchema">
+          Import Schema
+        </el-button>
+      </el-row>
+    </div>
+  </fragment>
+</template>
+
+<script lang="ts">
+import { Schema } from '@dockite/database';
+import { omit } from 'lodash';
+import { Component, Vue, Watch } from 'nuxt-property-decorator';
+import { Fragment } from 'vue-fragment';
+
+import ImportEditor from '~/components/schemas/import-editor.vue';
+import * as data from '~/store/data';
+import * as schema from '~/store/schema';
+
+@Component({
+  components: {
+    Fragment,
+    ImportEditor,
+  },
+})
+export default class ImportSchemaWithIdPage extends Vue {
+  public payload = '';
+
+  get schemaName(): string {
+    return this.$store.getters[`${data.namespace}/getSchemaNameById`](this.schemaId);
+  }
+
+  get schemaId(): string {
+    return this.$route.params.id;
+  }
+
+  get schema(): Schema {
+    return this.$store.getters[`${data.namespace}/getSchemaWithFieldsById`](this.$route.params.id);
+  }
+
+  public async handleImportSchema(): Promise<void> {
+    try {
+      await this.$store.dispatch(`${schema.namespace}/importSchema`, {
+        schemaId: this.schemaId,
+        payload: this.payload,
+      });
+
+      this.$message({
+        message: 'Schema imported successfully!',
+        type: 'success',
+      });
+
+      this.$router.replace('/schemas');
+    } catch (err) {
+      console.log(err);
+
+      this.$message({
+        message: 'Unable to import schema, please check for any errors.',
+        type: 'error',
+      });
+    }
+  }
+
+  public fetchSchemaById(force = false): Promise<void> {
+    return this.$store.dispatch(`${data.namespace}/fetchSchemaWithFieldsById`, {
+      id: this.$route.params.id,
+      force,
+    });
+  }
+
+  @Watch('schemaId', { immediate: true })
+  handleSchemaIdChange(): void {
+    this.fetchSchemaById();
+  }
+
+  @Watch('schema', { immediate: true })
+  handleSchemaChange(): void {
+    if (this.schema) {
+      this.payload = JSON.stringify(
+        {
+          ...omit(this.schema, ['id', 'type', 'createdAt', 'updatedAt', '__typename']),
+          groups: Object.keys(this.schema.groups).map(key => ({ [key]: this.schema.groups[key] })),
+          fields: this.schema.fields.map(field => omit(field, ['schemaId', '__typename'])),
+        },
+        null,
+        2,
+      );
+    }
+  }
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/admin/pages/schemas/_id/index.vue
+++ b/packages/admin/pages/schemas/_id/index.vue
@@ -44,6 +44,12 @@
                   Revisions
                 </router-link>
               </el-dropdown-item>
+              <el-dropdown-item>
+                <router-link :to="`/schemas/${schemaId}/import`">
+                  <i class="el-icon-upload2" />
+                  Import Schema
+                </router-link>
+              </el-dropdown-item>
             </el-dropdown-menu>
           </el-dropdown>
         </el-row>

--- a/packages/admin/pages/schemas/import.vue
+++ b/packages/admin/pages/schemas/import.vue
@@ -1,0 +1,58 @@
+<template>
+  <fragment>
+    <portal to="header">
+      <h2>Import Schema</h2>
+    </portal>
+
+    <div class="import-schema-page">
+      <import-editor v-model="payload" style="height: 60vh;" />
+      <div style="padding-top: 1rem;" />
+      <el-row type="flex" justify="space-between" align="middle">
+        <el-button type="text" @click="$router.go(-1)">Cancel</el-button>
+        <el-button type="primary" @click.prevent="handleImportSchema">
+          Import Schema
+        </el-button>
+      </el-row>
+    </div>
+  </fragment>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'nuxt-property-decorator';
+import { Fragment } from 'vue-fragment';
+
+import ImportEditor from '~/components/schemas/import-editor.vue';
+import * as schema from '~/store/schema';
+
+@Component({
+  components: {
+    Fragment,
+    ImportEditor,
+  },
+})
+export default class AllSchemasPage extends Vue {
+  public payload = '';
+
+  public async handleImportSchema(): Promise<void> {
+    try {
+      await this.$store.dispatch(`${schema.namespace}/importSchema`, { payload: this.payload });
+
+      this.$message({
+        message: 'Schema imported successfully!',
+        type: 'success',
+      });
+
+      this.$router.replace('/schemas');
+    } catch (err) {
+      console.log(err);
+
+      this.$message({
+        message: 'Unable to import schema, please check for any errors.',
+        type: 'error',
+      });
+    }
+  }
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/admin/pages/schemas/index.vue
+++ b/packages/admin/pages/schemas/index.vue
@@ -1,7 +1,23 @@
 <template>
   <fragment>
     <portal to="header">
-      <h2>All Schemas</h2>
+      <el-row type="flex" justify="space-between" align="middle">
+        <h2>All Schemas</h2>
+        <el-dropdown>
+          <el-button size="medium">
+            Actions
+            <i class="el-icon-arrow-down el-icon--right" />
+          </el-button>
+          <el-dropdown-menu slot="dropdown">
+            <el-dropdown-item>
+              <router-link :to="`/schemas/import`">
+                <i class="el-icon-upload2" />
+                Import Schema
+              </router-link>
+            </el-dropdown-item>
+          </el-dropdown-menu>
+        </el-dropdown>
+      </el-row>
     </portal>
 
     <div class="all-documents-page">

--- a/packages/admin/store/schema.ts
+++ b/packages/admin/store/schema.ts
@@ -10,11 +10,13 @@ import {
   DeleteSchemaMutationResponse,
   UnpersistedField,
   UpdateSchemaMutationResponse,
+  ImportSchemaMutationResponse,
 } from '~/common/types';
 import CreateFieldMutation from '~/graphql/mutations/create-field.gql';
 import CreateSchemaMutation from '~/graphql/mutations/create-schema.gql';
 import DeleteFieldMutation from '~/graphql/mutations/delete-field.gql';
 import DeleteSchemaMutation from '~/graphql/mutations/delete-schema.gql';
+import ImportSchemaMutation from '~/graphql/mutations/import-schema.gql';
 import UpdateFieldMutation from '~/graphql/mutations/update-field.gql';
 import UpdateSchemaMutation from '~/graphql/mutations/update-schema.gql';
 import AllSchemasQuery from '~/graphql/queries/all-schemas.gql';
@@ -153,6 +155,25 @@ export const actions: ActionTree<SchemaState, RootState> = {
 
     await this.dispatch(`${data.namespace}/fetchAllSchemas`, true);
     this.commit(`${data.namespace}/removeSchemaWithFields`, payload);
+  },
+
+  async importSchema(_, payload: { schemaId?: string; payload: string }) {
+    const { data: schemaData } = await this.$apolloClient.mutate<ImportSchemaMutationResponse>({
+      mutation: ImportSchemaMutation,
+      variables: {
+        schemaId: payload.schemaId ?? null,
+        payload: payload.payload,
+      },
+      update: () => {
+        this.$apolloClient.resetStore();
+      },
+    });
+
+    if (!schemaData?.importSchema) {
+      throw new Error('Unable to delete schema');
+    }
+
+    await this.dispatch(`${data.namespace}/fetchAllSchemas`, true);
   },
 };
 

--- a/packages/admin/types/ambient.d.ts
+++ b/packages/admin/types/ambient.d.ts
@@ -1,3 +1,4 @@
 declare module 'element-ui/lib/locale/lang/en';
 declare module 'portal-vue';
 declare module 'unidiff';
+declare module 'jsonlint-mod';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@graphql-modules/core": "^0.7.14",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
+    "ajv": "^6.12.2",
     "apollo-server-express": "^2.10.1",
     "axios": "^0.19.2",
     "bcrypt": "^4.0.0",

--- a/packages/core/src/common/scopes.ts
+++ b/packages/core/src/common/scopes.ts
@@ -11,6 +11,7 @@ const SCHEMA_SCOPES = [
   'internal:schema:create',
   'internal:schema:read',
   'internal:schema:update',
+  'internal:schema:import',
   'internal:schema:delete',
 ];
 

--- a/packages/core/src/modules/external/dockite.ts
+++ b/packages/core/src/modules/external/dockite.ts
@@ -7,7 +7,7 @@ import { FieldManager, registerScopes, registerScopeResourceId } from '@dockite/
 // TODO: Tidy this area, createSchema likely does not need access to all the items it currently does.
 export const createExtraGraphQLSchema = async (): Promise<GraphQLSchema> => {
   const dockiteSchemas = await getRepository(Schema).find({
-    relations: ['fields'],
+    relations: ['fields', 'fields.schema'],
   });
 
   dockiteSchemas.forEach(schema => {

--- a/packages/core/src/modules/internal/validation/schema-import.ts
+++ b/packages/core/src/modules/internal/validation/schema-import.ts
@@ -1,0 +1,102 @@
+import Ajv from 'ajv';
+
+export const ajv = new Ajv({ allErrors: true });
+
+export const validationSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+    },
+    name: {
+      type: 'string',
+    },
+    title: {
+      type: 'string',
+    },
+    groups: {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          minProperties: 1,
+          maxProperties: 1,
+          patternProperties: {
+            '^.*$': {
+              type: 'array',
+              items: [
+                {
+                  type: 'string',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+    settings: {
+      type: 'object',
+    },
+    fields: {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: {
+            id: {
+              type: 'string',
+            },
+            name: {
+              type: 'string',
+            },
+            title: {
+              type: 'string',
+            },
+            description: {
+              type: 'string',
+            },
+            type: {
+              type: 'string',
+            },
+            settings: {
+              type: 'object',
+              properties: {
+                children: {
+                  type: 'array',
+                  items: [
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                        },
+                        type: {
+                          type: 'string',
+                        },
+                        title: {
+                          type: 'string',
+                        },
+                        settings: {
+                          type: 'object',
+                        },
+                        description: {
+                          type: 'string',
+                        },
+                      },
+                      required: ['name', 'type', 'title', 'settings', 'description'],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          required: ['name', 'title', 'description', 'type', 'settings'],
+        },
+      ],
+    },
+  },
+  required: ['name', 'title', 'groups', 'settings', 'fields'],
+};
+
+export const validator = ajv.compile(validationSchema);

--- a/packages/core/src/utils/fire-webhooks.ts
+++ b/packages/core/src/utils/fire-webhooks.ts
@@ -67,7 +67,6 @@ export const fireWebhooks = async (entity: object, action: WebhookAction): Promi
 
         if (SchemaManager.internalSchema) {
           log('firing graphql webhooks');
-          log(webhook.options.query);
           return graphql(SchemaManager.internalSchema, webhook.options.query, undefined, {
             user: {
               id: '00000000-0000-0000-0000-000000000000',
@@ -80,15 +79,12 @@ export const fireWebhooks = async (entity: object, action: WebhookAction): Promi
             } as UserContext,
           }).then(
             result => {
-              log(result);
-
               return Axios({
                 url: webhook.url,
                 method: webhook.method as Method,
                 data: webhook.method.toLowerCase() === 'get' ? undefined : JSON.stringify(result),
               }).then(
                 (response: AxiosResponse) => {
-                  log(response);
                   return webhookCallRepository.insert({
                     executedAt: new Date(),
                     request: {
@@ -104,7 +100,6 @@ export const fireWebhooks = async (entity: object, action: WebhookAction): Promi
                   });
                 },
                 (error: AxiosError) => {
-                  log(error);
                   return webhookCallRepository.insert({
                     executedAt: new Date(),
                     request: {

--- a/packages/database/src/repositories/index.ts
+++ b/packages/database/src/repositories/index.ts
@@ -1,2 +1,3 @@
+export * from './schema-import';
 export * from './schema-revision';
 export * from './search-engine';

--- a/packages/database/src/repositories/schema-import.ts
+++ b/packages/database/src/repositories/schema-import.ts
@@ -1,0 +1,78 @@
+import { EntityRepository, getRepository, Repository } from 'typeorm';
+import { omit, cloneDeep } from 'lodash';
+
+import { Schema, Field, SchemaRevision } from '../entities';
+
+@EntityRepository(Schema)
+export class SchemaImportRepository extends Repository<Schema> {
+  public async importSchema(
+    schemaId: string | null,
+    payload: Schema,
+    userId: string,
+  ): Promise<Schema | null> {
+    const schemaRepository = getRepository(Schema);
+    const fieldRepository = getRepository(Field);
+    const revisionRepository = getRepository(SchemaRevision);
+
+    let schema: Schema | null = null;
+
+    if (schemaId) {
+      schema = await schemaRepository.findOneOrFail(schemaId);
+    } else {
+      schema = new Schema();
+    }
+
+    const schemaFields = schema.fields ?? [];
+
+    const fieldsToBeImported = payload.fields.map(field => {
+      if (!field.id) {
+        const fieldMatch = schemaFields.find(f => f.id === field.id || f.name === field.name);
+
+        if (fieldMatch) {
+          // Easier than ignoring the eslint rule
+          Object.assign(field, { id: fieldMatch.id });
+        }
+      }
+
+      return field;
+    });
+
+    const fieldsToBeDeleted = schemaFields.filter(
+      field =>
+        !fieldsToBeImported.some(
+          fieldToImport => field.id === fieldToImport.id || fieldToImport.name === field.name,
+        ),
+    );
+
+    const newSchema = {
+      ...schema,
+      ...omit(payload, ['fields']),
+      userId,
+    };
+
+    if (schemaId) {
+      newSchema.id = schemaId;
+    }
+
+    if (schemaId) {
+      const revision = revisionRepository.create({
+        schemaId: schema.id,
+        data: cloneDeep(schema) as Record<string, any>,
+        userId: schema.userId ?? '',
+      });
+
+      await revisionRepository.save(revision);
+    }
+
+    const savedSchema = await schemaRepository.save(newSchema);
+
+    await Promise.all([
+      fieldRepository.remove(fieldsToBeDeleted),
+      fieldRepository.save(
+        fieldsToBeImported.map(field => Object.assign(field, { schemaId: savedSchema.id })),
+      ),
+    ]);
+
+    return savedSchema;
+  }
+}

--- a/packages/database/src/repositories/schema-revision.ts
+++ b/packages/database/src/repositories/schema-revision.ts
@@ -2,10 +2,9 @@ import { cloneDeep, omit } from 'lodash';
 import { EntityRepository, getRepository, Repository } from 'typeorm';
 
 import { Field, Schema, SchemaRevision } from '../entities';
-import { SearchEngine } from '../entities/search-engine';
 
-@EntityRepository(SearchEngine)
-export class SchemaRevisionRepository extends Repository<SearchEngine> {
+@EntityRepository(Schema)
+export class SchemaRevisionRepository extends Repository<Schema> {
   public async restoreRevision(
     schemaId: string,
     revisionId: string,

--- a/packages/field-group/src/index.ts
+++ b/packages/field-group/src/index.ts
@@ -87,7 +87,7 @@ export class DockiteFieldGroup extends DockiteField {
     >[];
 
     const objectType = new GraphQLObjectType({
-      name: String(this.schemaField.name),
+      name: `${this.schemaField.schema?.name || 'Unknown'}_${String(this.schemaField.name)}`,
       fields: cleanedFields.reduce((a, b) => ({ ...a, [b.name]: b.config }), {}),
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3632,6 +3632,11 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+JSV@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+  integrity sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=
+
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
@@ -3734,7 +3739,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -9898,6 +9903,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonlint-mod@^1.7.5:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/jsonlint-mod/-/jsonlint-mod-1.7.5.tgz#678d2b600b9d350ec3448373d6f71dcbf09a0e3d"
+  integrity sha512-VqTFtMj9JXv4qGSfcoYTgXgsGkTW4aXZer8u4vR64RAPjK37BUkNKmd3mTjuRTs1vQrE+yuzfzDhgB2SAyPvlA==
+  dependencies:
+    JSV "^4.0.2"
+    chalk "^2.4.2"
+    underscore "^1.9.1"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -15422,6 +15436,11 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+underscore@^1.9.1:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
+  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 unfetch@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Add the ability to import a schema via JSON instead of using the UI to drag and drop schema elements. This allows for outside creation and version of schemas and their corresponding updates.

Additionally fix the **group-field** to no longer incur schema type clashes by prefixing the fields type with the name of the schema it is associated with.