### PR TITLE
feat(field-group): validation in multiple of x

### DIFF
--- a/packages/field-group/src/index.ts
+++ b/packages/field-group/src/index.ts
@@ -36,6 +36,7 @@ export class DockiteFieldGroup extends DockiteField {
     repeatable: false,
     minRows: 0,
     maxRows: Infinity,
+    multipleOf: 1,
     children: [],
   };
 

--- a/packages/field-group/src/types.ts
+++ b/packages/field-group/src/types.ts
@@ -23,4 +23,5 @@ export interface GroupFieldSettings extends FieldSettings {
   repeatable: boolean;
   minRows: number;
   maxRows: number;
+  multipleOf: number;
 }

--- a/packages/field-group/src/ui/Input.vue
+++ b/packages/field-group/src/ui/Input.vue
@@ -239,6 +239,10 @@ export default class GroupFieldInputComponent extends Vue {
       if (this.settings.maxRows) {
         this.rules.push(this.getMaxRule());
       }
+
+      if (this.settings.multipleOf) {
+        this.rules.push(this.getMultipleOfXRule());
+      }
     }
   }
 
@@ -264,6 +268,25 @@ export default class GroupFieldInputComponent extends Vue {
       type: 'array',
       max: this.settings.maxRows,
       message: `${this.fieldConfig.title} must contain at most ${this.settings.maxRows} rows.`,
+      trigger: 'blur',
+    };
+  }
+
+  public getMultipleOfXRule(): object {
+    const { settings } = this;
+    return {
+      type: 'array',
+      validator(_rule: never, value: object[], callback: Function) {
+        if (value === null || value.length === 0) {
+          return callback();
+        }
+
+        if (value.length % settings.multipleOf !== 0) {
+          return callback(false);
+        }
+        return callback();
+      },
+      message: `${this.fieldConfig.title} must contain an amount of items that is a multiple of ${this.settings.multipleOf}.`,
       trigger: 'blur',
     };
   }

--- a/packages/field-group/src/ui/Settings.vue
+++ b/packages/field-group/src/ui/Settings.vue
@@ -12,6 +12,9 @@
     <el-form-item label="Max Rows">
       <el-input-number v-model="settings.maxRows" />
     </el-form-item>
+    <el-form-item label="Multiple Of">
+      <el-input-number v-model="settings.multipleOf" />
+    </el-form-item>
   </fragment>
 </template>
 
@@ -25,6 +28,7 @@ interface Settings {
   repeatable: boolean;
   minRows: number;
   maxRows: number;
+  multipleOf: number;
 }
 
 interface SchemaResults {
@@ -58,6 +62,7 @@ export default class GroupFieldSettingsComponent extends Vue {
       repeatable: false,
       minRows: 0,
       maxRows: Infinity,
+      multipleOf: 1,
     };
   }
 


### PR DESCRIPTION
When using 'repeatable' in group-field, this setting allow forcing the number of children must be a multiple of x (eg. x = 3, number of children = 0, 3, 6, 9, ... )