### PR TITLE
Fix field-group item delete button position

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,12 +18,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - run: yarn global add lerna
-    - run: echo "::add-path::$(yarn global bin)"
-
-    - run: lerna bootstrap
-    - run: lerna run build --scope @dockite/types
-    - run: lerna run build --scope @dockite/manager
-    - run: lerna run build --ignore @dockite/admin --ignore @dockite/core --ignore @dockite/field-* --parallel
-    - run: lerna run build --scope @dockite/field-* --parallel
-    - run: lerna run build --scope @dockite/core --scope @dockite/admin --parallel
+    - run: yarn install
+    - run: yarn lerna bootstrap
+    - run: yarn lerna run build --scope @dockite/types
+    - run: yarn lerna run build --scope @dockite/manager
+    - run: yarn lerna run build --ignore @dockite/admin --ignore @dockite/core --ignore @dockite/field-*
+    - run: yarn lerna run build --scope @dockite/field-* --parallel
+    - run: yarn lerna run build --scope @dockite/core --scope @dockite/admin --parallel

--- a/packages/field-group/src/ui/Input.vue
+++ b/packages/field-group/src/ui/Input.vue
@@ -69,8 +69,7 @@
                       />
 
                       <el-button
-                        class="dockite-group--movement-button dockite--group-movement-button__delete absolute"
-                        style="bottom: -50px"
+                        class="dockite-group--movement-button dockite--group-movement-button__delete"
                         type="text"
                         title="Remove the current group item"
                         icon="el-icon-delete"
@@ -423,13 +422,13 @@ export default class GroupFieldInputComponent extends Vue {
   }
 
   .dockite--group-movement-button__delete {
-    opacity: 0;
+    display: none;
     transition: all 300ms;
   }
 
   .dockite-field-group--item:hover {
     .dockite--group-movement-button__delete {
-      opacity: 1;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
Currently the delete button is positioned outside below the item, and only appear when item is mouse-over.
Thus when mouse-out to reach it, it is disappear, make it un-clickable.

This PR remove the absolute position and put the button into inside item, aligned in column with other button.