### PR TITLE
feat: login redirect admin user to previous page

### DIFF
--- a/packages/admin/components/base/side-menu.vue
+++ b/packages/admin/components/base/side-menu.vue
@@ -409,8 +409,9 @@ export default class SideMenuComponent extends Vue {
 
   public async logout(): Promise<void> {
     await this.$store.dispatch(`${namespace}/logout`);
+    const query = { redirectTo: decodeURIComponent(this.$route.path) };
 
-    this.$router.push('/login');
+    this.$router.push({ path: '/login', query });
   }
 }
 </script>

--- a/packages/admin/pages/login.vue
+++ b/packages/admin/pages/login.vue
@@ -124,6 +124,7 @@ export default class LoginPage extends Vue {
   public async login(): Promise<void> {
     try {
       this.loading += 1;
+      const redirectRoute = encodeURIComponent(this.$route.query.redirectTo.toString());
 
       const valid = await (this.$refs.form as Form).validate();
 
@@ -135,7 +136,11 @@ export default class LoginPage extends Vue {
 
       await this.$store.dispatch(`${namespace}/login`, this.loginForm);
 
-      this.$router.push('/');
+      if (redirectRoute) {
+        this.$router.push(redirectRoute);
+      }
+
+      this.$router.back();
     } catch (_) {
       this.error = 'The username or password provided is incorrect.';
     } finally {


### PR DESCRIPTION
Add the ability to be redirected to the previous route when you are navigated to the login page as a result of not being authenticated. Defaults to moving back a route segment in the event that a `redirectTo` query param doesn't exist.
